### PR TITLE
Fix FOUC

### DIFF
--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -7,6 +7,11 @@ import theme from '../../styles/theme.js';
 const GlobalStyles = createGlobalStyle`
   @import url('https://fonts.googleapis.com/css?family=Space+Mono:400,700|Work+Sans:300,400,700');
 
+  /* Show content hidden by index.css (prevents FOUC). */
+  body {
+    opacity: 1;
+  }
+
   html {
     box-sizing: border-box;
   }
@@ -78,6 +83,7 @@ const Page = ({ children, themeVariant }) => {
       render={data => (
         <ThemeProvider theme={theme(themeVariant)}>
           <Root>
+            <GlobalStyles />
             <Helmet>
               <html lang="en" />
               <title>{data.site.siteMetadata.title}</title>
@@ -86,7 +92,6 @@ const Page = ({ children, themeVariant }) => {
                 content="VfiHt_hBis8VcZHpXz3bMhNvBbmIVc_iMWVlZ3UjSJw"
               />
             </Helmet>
-            <GlobalStyles />
             {children}
           </Root>
         </ThemeProvider>

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -1,0 +1,4 @@
+/* Prevent FOUC by hiding content and showing in Page.js */
+body {
+  opacity: 0;
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import About from '../components/About/About';
 import NoteList from '../components/NoteList/NoteList';
 import Page from '../components/Page/Page';
+import './index.css';
 
 const Slide = styled.div`
   min-height: 100vh;


### PR DESCRIPTION
Fixes a flash of unstyled content (FOUC) that is related to styled-components but not fixed by gatsby-plugin-styled-components. Even when SSR is working the styles aren't being inlined so there's a delay.